### PR TITLE
fix(axios): Reassign headers to extend with concat operation

### DIFF
--- a/packages/plantae/src/axios/createAxiosInterceptors.ts
+++ b/packages/plantae/src/axios/createAxiosInterceptors.ts
@@ -26,10 +26,11 @@ function extendClientRequest(
 ): InternalAxiosRequestConfig {
   const { body: data, headers, ...rest } = adapterRequest;
 
-  clientRequest.headers.concat(Object.fromEntries(headers?.entries() ?? []));
-
   return {
     ...clientRequest,
+    headers: clientRequest.headers.concat(
+      Object.fromEntries(headers?.entries() ?? [])
+    ),
     data,
     ...rest,
   };
@@ -56,10 +57,9 @@ function extendClientResponse(
 
   const axiosHeaders = clientResponse.headers as AxiosResponseHeaders;
 
-  axiosHeaders.concat(Object.fromEntries(headers?.entries() ?? []));
-
   return {
     ...clientResponse,
+    headers: axiosHeaders.concat(Object.fromEntries(headers?.entries() ?? [])),
     data,
     ...rest,
   };


### PR DESCRIPTION
Fixed an issue where headers changes were not reflected in the axios plugin.

- Since the concat method does not change the object it references, this was resolved by reassigning the object.