### PR TITLE
feat(axios)!: implement `onRejected` interface

### DIFF
--- a/.changeset/healthy-stingrays-fail.md
+++ b/.changeset/healthy-stingrays-fail.md
@@ -1,0 +1,5 @@
+---
+"plantae": minor
+---
+
+feat: implement onRejected interface (BREAKING CHANGE)

--- a/packages/plantae/README.md
+++ b/packages/plantae/README.md
@@ -74,8 +74,8 @@ const { request, response } = createAxiosInterceptors({
   plugins: [myPlugin()],
 });
 
-myAxios.interceptors.request.use(request);
-myAxios.interceptors.response.use(response);
+myAxios.interceptors.request.use(request.onFulfilled, request.onRejected);
+myAxios.interceptors.response.use(response.onFulfilled, request.onRejected);
 
 export { myAxios };
 ```


### PR DESCRIPTION
**BREAKING CHANGES**

Status codes treated as errors (4xx, 5xx..) couldn't be handled by interceptors created by `createAxiosInterceptors` so far.

Because Axios handles those responses via `onRejected`, the second parameter for `use` function and that hasn't been provided yet.

This behavior restricts the role of the plugin, so we've implemented an additional `onRejected` handler that can be used as a parameter to Axios interceptors.