### PR TITLE
fix: Apply OIDC auth to publish packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,4 +39,3 @@ jobs:
           version: yarn version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Description

### Summary

This commit transitions the package publishing workflow from token-based authentication to OpenID Connect (OIDC) authentication by removing the explicit `NPM_TOKEN` environment variable reference from the GitHub Actions workflow configuration.

### Technical Details

The modification involves removing the `NPM_TOKEN` secret environment variable from the changesets publishing step in [.github/workflows/publish.yml](.github/workflows/publish.yml#L41). This change reflects the adoption of OIDC-based authentication, which provides a more secure authentication mechanism by eliminating the need for long-lived, static authentication tokens.

### Security and Operational Benefits

**Enhanced Security Posture:**
- Eliminates the requirement to store and manage long-lived npm authentication tokens as repository secrets
- Reduces the attack surface by removing static credentials that could be compromised or leaked
- Leverages short-lived, automatically-rotating credentials generated through the OIDC trust relationship

**Improved Operational Efficiency:**
- Removes the maintenance burden associated with token rotation and renewal
- Simplifies the authentication workflow by relying on GitHub's native identity provider integration
- Reduces the risk of publishing failures due to expired or revoked tokens

### Implementation Context

The workflow maintains the `permissions: write-all` configuration, which grants the necessary permissions for the GitHub Actions job to obtain OIDC tokens and authenticate with npm's registry. The changesets/action package publishing mechanism remains unchanged, with only the authentication method being modernized.

This change aligns with current best practices for GitHub Actions security and npm registry authentication patterns.